### PR TITLE
Add address list and section jumper to delivery detail page.

### DIFF
--- a/delivery/views.py
+++ b/delivery/views.py
@@ -5,7 +5,7 @@ from django.utils.datastructures import SortedDict
 
 from datetime import datetime, timedelta
 
-from order.models import DeliveryWindow, Order
+from order.models import DeliveryWindow, Invoice
 
 def summary(request):
   def divide_delivery_window_by_days(delivery_windows):
@@ -43,10 +43,12 @@ def detail(request, id):
     return items
 
   delivery_window = DeliveryWindow.objects.get(id=id)
+  invoices = filter(lambda invoice: invoice.status != Invoice.STATUS_PENDING, map(lambda order: order.invoice, delivery_window.orders.all()))
 
   context = Context({
     'delivery_window': delivery_window,
-    'combined_items': combine_items(delivery_window.waiting_orders)
+    'combined_items': combine_items(delivery_window.waiting_orders),
+    'invoices': invoices,
   })
 
   template = loader.get_template('delivery/detail.html')

--- a/ntemplates/delivery/detail.html
+++ b/ntemplates/delivery/detail.html
@@ -10,6 +10,8 @@
 
 {% block content %}
 
+<h2>{{ delivery_window.store }}: {{ delivery_window }}</h2>
+
 <h3>Shopping List</h3>
 <ul class="shopping-list">
   {% for item, quantity in combined_items.items %}
@@ -32,9 +34,9 @@
 </ul>
 
 <h3>Order List</h3>
-<ul>
+<ul class="order-list">
   {% for order in delivery_window.waiting_orders %}
-  <li>
+  <li id="order-{{ order.id }}">
     <div class="order-title">
       <a href="{% url 'order:show' order.invoice.invoice_num %}">
         Order {{ order }}: {{ order.invoice.customer_name }} ({{ order.items.count }} items)
@@ -71,6 +73,30 @@
           <span>{{ order_item.item.name }}</span>
           <label><input type="checkbox" {% if order_item.allow_sub %}checked{% endif %} disabled>Sub</label>
         </span>
+      </li>
+      {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
+
+<h3>Address List</h3>
+<ul class="address-list">
+  {% for invoice in invoices %}
+  <li class="address">
+    <div class="address-title">{{ invoice.address }} {{ invoice.postcode }}</div>
+    <div>Invoice #{{ invoice.id }}: <span class="address-invoice-status">{{ invoice.get_status_display }}</span></div>
+    <div>{{ invoice.customer_name }} ({{ invoice.phone }})</div>
+    <ul class="address-order-list">
+      {% for order in invoice.orders.all %}
+      <li class="address-order">
+        {% if order.delivery_window == delivery_window %}
+        <a href="#order-{{ order.id }}">
+        {% else %}
+        <a href="{% url 'delivery:detail' order.delivery_window.id %}#order-{{ order.id }}">
+        {% endif %}
+          Order #{{ order.id }}: {{ order.get_status_display }} ({{ order.delivery_window.store }})
+        </a>
       </li>
       {% endfor %}
     </ul>

--- a/ntemplates/delivery/detail.html
+++ b/ntemplates/delivery/detail.html
@@ -12,7 +12,14 @@
 
 <h2>{{ delivery_window.store }}: {{ delivery_window }}</h2>
 
-<h3>Shopping List</h3>
+<h3 id="content-index">Jump to section</h3>
+<ul class="content-index">
+  <li><a href="#shopping-list">Shopping List</a></li>
+  <li><a href="#order-list">Order List</a></li>
+  <li><a href="#address-list">Address List</a></li>
+</ul>
+
+<h3 id="shopping-list">Shopping List</h3>
 <ul class="shopping-list">
   {% for item, quantity in combined_items.items %}
   <li class="item">
@@ -33,7 +40,7 @@
   {% endfor %}
 </ul>
 
-<h3>Order List</h3>
+<h3 id="order-list">Order List</h3>
 <ul class="order-list">
   {% for order in delivery_window.waiting_orders %}
   <li id="order-{{ order.id }}">
@@ -80,7 +87,7 @@
   {% endfor %}
 </ul>
 
-<h3>Address List</h3>
+<h3 id="address-list">Address List</h3>
 <ul class="address-list">
   {% for invoice in invoices %}
   <li class="address">

--- a/static/styles/delivery.css
+++ b/static/styles/delivery.css
@@ -73,6 +73,22 @@ a:hover {
   font-size: 15px;
 }
 
+.address-list .address-title {
+  font-size: 20px;
+  font-weight: bold;
+  color: red;
+}
+
+.address-list .address-invoice-status {
+  font-weight: bold;
+}
+
+.address-list .address-order-list {
+  list-style-type: circle;
+  padding-left: 20px;
+  font-weight: bold;
+}
+
 .back-button {
   font-size: 20px;
   font-weight: bold;


### PR DESCRIPTION
## Address List
- Address
  - Invoice #***: STATUS  
    NAME (PHONE)
    - Order #***: STATUS (STORE)
    - Order #***: STATUS (STORE)
    - Order #***: STATUS (STORE)

![ios simulator screen shot feb 8 2014 18 45 28](https://f.cloud.github.com/assets/510089/2119271/e51ff8c4-9158-11e3-9ead-6cc900e04c90.png)

Click on any order will scroll the page to display corresponding order if the order is under current delivery window. Or it will redirect you to that order's delivery window and scroll to the order detail as well. 

Section jumper is a list of hash tag links which jump to different sections. 
