### PR TITLE
Allows REST API response to be ordered

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -72,3 +72,4 @@ class CouponViewSet(viewsets.ReadOnlyModelViewSet):
 class DeliveryBucketViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = DeliveryBucket.objects.all()
     serializer_class = DeliveryBucketSerializer
+    ordering = ['-start']

--- a/api/views.py
+++ b/api/views.py
@@ -20,6 +20,7 @@ class ItemFilter(django_filters.FilterSet):
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    ordering_fields = ['date_joined', 'last_login']
 
 # Shop
 class StoreViewSet(viewsets.ReadOnlyModelViewSet):
@@ -38,6 +39,7 @@ class ItemViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Item.objects.all()
     serializer_class = ItemSerializer
     filter_class = ItemFilter
+    ordering_fields = ['sold_number']
 
 # Order
 class DeliveryWindowViewSet(viewsets.ReadOnlyModelViewSet):
@@ -48,11 +50,15 @@ class OrderViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
     filter_fields = ['status', 'invoice__invoice_num']
+    ordering = ['-when_created']
+    ordering_fields = ['when_created', 'when_updated', 'subtotal']
 
 class InvoiceViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Invoice.objects.all()
     serializer_class = InvoiceSerializer
     filter_fields = ['status', 'email', 'user__username']
+    ordering = ['-when_created']
+    ordering_fields = ['when_created', 'when_updated', 'subtotal']
 
 class OrderItemViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = OrderItem.objects.all()

--- a/config/settings.py
+++ b/config/settings.py
@@ -162,7 +162,10 @@ REST_FRAMEWORK = {
 
     'PAGINATE_BY': 10,
     'PAGINATE_BY_PARAM': 'page_size',
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': [
+        'rest_framework.filters.DjangoFilterBackend',
+        'rest_framework.filters.OrderingFilter',
+    ],
 }
 
 # A sample logging configuration. The only tangible logging


### PR DESCRIPTION
`Orders` and `Invoices` are now ordered reverse chronologically by default.

Those classes with `ordering_fields` specified can be ordered by these fields:
e.g. `/api/users/?ordering=-date_joined` will return users ordered reverse chronologically.
