### PR TITLE
[Vender] Enable clicktale only on home and shop page

### DIFF
--- a/ntemplates/common/base.html
+++ b/ntemplates/common/base.html
@@ -23,7 +23,7 @@
     {% block extra_script %}{% endblock %}
   </head>
   <body>
-    {% include "common/clicktale_top.html" %}
+    {% block body_open %}{% endblock %}
     <header>
       <nav class="navbar navbar-default" role="navigation">
         <div class="container-fluid">
@@ -159,6 +159,6 @@
     {% block page_script %}{% endblock %}
     {% include "common/analytics.html" %}
     {% include "common/uservoice.html" %}
-    {% include "common/clicktale_bottom.html" %}
+    {% block body_close %}{% endblock %}
   </body>
 </html>

--- a/ntemplates/common/base.html
+++ b/ntemplates/common/base.html
@@ -23,7 +23,6 @@
     {% block extra_script %}{% endblock %}
   </head>
   <body>
-    {% block body_open %}{% endblock %}
     <header>
       <nav class="navbar navbar-default" role="navigation">
         <div class="container-fluid">
@@ -159,6 +158,5 @@
     {% block page_script %}{% endblock %}
     {% include "common/analytics.html" %}
     {% include "common/uservoice.html" %}
-    {% block body_close %}{% endblock %}
   </body>
 </html>

--- a/ntemplates/page/home.html
+++ b/ntemplates/page/home.html
@@ -12,8 +12,8 @@
 <link rel="stylesheet" type="text/css" href="{% static "styles/home.css" %}"/>
 {% endblock %}
 
-{% block body_open %}
-  {% include "common/clicktale_top.html" %}
+{% block extra_script %}
+{% include "common/clicktale_top.html" %}
 {% endblock %}
 
 {% block header_content %}
@@ -220,8 +220,5 @@
     };
   });
 </script>
-{% endblock %}
-
-{% block body_close %}
-  {% include "common/clicktale_bottom.html" %}
+{% include "common/clicktale_bottom.html" %}
 {% endblock %}

--- a/ntemplates/page/home.html
+++ b/ntemplates/page/home.html
@@ -12,6 +12,10 @@
 <link rel="stylesheet" type="text/css" href="{% static "styles/home.css" %}"/>
 {% endblock %}
 
+{% block body_open %}
+  {% include "common/clicktale_top.html" %}
+{% endblock %}
+
 {% block header_content %}
 {% endblock %}
 
@@ -216,4 +220,8 @@
     };
   });
 </script>
+{% endblock %}
+
+{% block body_close %}
+  {% include "common/clicktale_bottom.html" %}
 {% endblock %}

--- a/ntemplates/shop/base.html
+++ b/ntemplates/shop/base.html
@@ -8,6 +8,10 @@
 <link rel="stylesheet" type="text/css" href="{% static "styles/item_detail.css" %}"/>
 {% endblock %}
 
+{% block body_open %}
+  {% include "common/clicktale_top.html" %}
+{% endblock %}
+
 {% block header_content %}
 <ul class="nav navbar-nav">
   <li class="dropdown">
@@ -82,4 +86,8 @@
     }
   });
 </script>
+{% endblock %}
+
+{% block body_close %}
+  {% include "common/clicktale_bottom.html" %}
 {% endblock %}

--- a/ntemplates/shop/base.html
+++ b/ntemplates/shop/base.html
@@ -8,8 +8,8 @@
 <link rel="stylesheet" type="text/css" href="{% static "styles/item_detail.css" %}"/>
 {% endblock %}
 
-{% block body_open %}
-  {% include "common/clicktale_top.html" %}
+{% block extra_script %}
+{% include "common/clicktale_top.html" %}
 {% endblock %}
 
 {% block header_content %}
@@ -86,8 +86,5 @@
     }
   });
 </script>
-{% endblock %}
-
-{% block body_close %}
-  {% include "common/clicktale_bottom.html" %}
+{% include "common/clicktale_bottom.html" %}
 {% endblock %}


### PR DESCRIPTION
I guess if there is a limit of 100 page recordings per day, we should only record the most important pages. I don't think we can get much user insights from recording account page or order page etc.
